### PR TITLE
T2994 - Erro no Retorno do CNAB400 - Itaú

### DIFF
--- a/cnab240/bancos/itau_cobranca_retorno_400/specs/transacao_tipo_1.json
+++ b/cnab240/bancos/itau_cobranca_retorno_400/specs/transacao_tipo_1.json
@@ -171,7 +171,8 @@
       "nome": "banco_cobrador",
       "posicao_inicio": 166,
       "posicao_fim": 168,
-      "formato": "num"
+      "formato": "num",
+      "default": 0
     },
     
     "25.3P": {

--- a/cnab240/registro.py
+++ b/cnab240/registro.py
@@ -185,7 +185,12 @@ class RegistroBase(object):
                 try:
                     campo.valor = int(valor)
                 except ValueError:
-                    raise errors.TipoError(campo, valor)
+                    # Se tiver campo default, não gera o Erro para dar sequencia
+                    # na importação do CNAB
+                    if campo.default is not None:
+                        campo.valor = campo.default
+                    else:
+                        raise errors.TipoError(campo, valor)
             else:
                 campo.valor = valor
 


### PR DESCRIPTION
# Descrição

[FIX] Trata a exceção na conversão para Inteiro no Retorno CNAB

Adiciona a verificação do campo Default, onde agora somente gera
a exceção quando não informado o valor Default para o campo, assim
não interrompe a importação do arquivo do CNAB.

# Informações adicionais

[T2994](https://multi.multidadosti.com.br/web?debug#id=3403&view_type=form&model=project.task&action=323&active_id=61)
