### PR TITLE
T5970 - erro ao tentar processar o arquivo de CNAB

### DIFF
--- a/cnab240/registro.py
+++ b/cnab240/registro.py
@@ -185,12 +185,10 @@ class RegistroBase(object):
                 try:
                     campo.valor = int(valor)
                 except ValueError:
-                    # Se tiver campo default, não gera o Erro para dar sequencia
-                    # na importação do CNAB
                     if campo.default is not None:
                         campo.valor = campo.default
                     else:
-                        raise errors.TipoError(campo, valor)
+                        campo.valor = 0
             else:
                 campo.valor = valor
 


### PR DESCRIPTION
# Descrição

[FIX] Ajusta tratamento de erro do retorno do CNAB lib 'cnab240'

- Substitui o ERRO na conversão de Valor para 0 na atribuição
  do campo quando vem em branco o arquivo do retorno do banco.

# Informações adicionais

Dados da tarefa: [T5970](https://multi.multidados.tech/web?#id=6379&action=328&model=project.task&view_type=form&menu_id=465)

