### PR TITLE
T6406 - Erro: CNAB Santander layout 400

### DIFF
--- a/cnab240/bancos/santander_cobranca_400/specs/transacao_tipo_1.json
+++ b/cnab240/bancos/santander_cobranca_400/specs/transacao_tipo_1.json
@@ -50,14 +50,14 @@
         "posicao_inicio": 70,
         "posicao_fim": 70,
         "formato": "num"
-      },
+    },
 
     "08.3P": {
       "nome": "branco_03",
       "posicao_inicio": 71,
       "posicao_fim": 76,
-      "formato": "alfa",
-      "default": ""
+      "formato": "num",
+      "default": 0
     },
 
     "09.3P": {


### PR DESCRIPTION
# Descrição

[FIX] Corrige Layout TXT CNAB 400 Santander Lib 'cnab240'

- Passando campo de Alfa para Num para gerar zeros ao inves de
  espaços em branco.

# Informações adicionais

Dados da tarefa: [T6406](https://multi.multidados.tech/web?#id=6815&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)


