### PR TITLE
T6541 - Verificar erro ao gerar arquivo de remessa homologação nas empresa Elan e Francisco (SANTANDER)

### DIFF
--- a/cnab240/bancos/santander_cobranca_400/specs/header_arquivo.json
+++ b/cnab240/bancos/santander_cobranca_400/specs/header_arquivo.json
@@ -82,12 +82,28 @@
     "11.0": {
       "nome": "branco_03",
       "posicao_inicio": 101,
-      "posicao_fim": 394,
-      "formato": "alfa",
-      "default": ""
+      "posicao_fim": 116,
+      "formato": "num",
+      "default": 0
     },
 
     "12.0": {
+        "nome": "branco_04",
+        "posicao_inicio": 117,
+        "posicao_fim": 391,
+        "formato": "alfa",
+        "default": ""
+    },
+
+    "13.0": {
+        "nome": "branco_05",
+        "posicao_inicio": 392,
+        "posicao_fim": 394,
+        "formato": "num",
+        "default": 0
+    },
+
+    "14.0": {
       "nome": "num_seq_registro",
       "posicao_inicio": 395,
       "posicao_fim": 400,

--- a/cnab240/bancos/santander_cobranca_400/specs/transacao_tipo_1.json
+++ b/cnab240/bancos/santander_cobranca_400/specs/transacao_tipo_1.json
@@ -105,8 +105,7 @@
         "nome": "brancos_4",
         "posicao_inicio": 98,
         "posicao_fim": 101,
-        "formato": "num",
-        "default": 0
+        "formato": "alfa"
     },
 
     "15.3P": {
@@ -158,8 +157,8 @@
       "nome": "banco_encarregado_cobranca",
       "posicao_inicio": 140,
       "posicao_fim": 142,
-      "formato": "num",
-      "default": 341
+      "formato": "alfa",
+      "default": "033"
     },
 
     "22.3P": {


### PR DESCRIPTION
# Descrição

[FIX] Ajusta CNAB 400 Santander modulo 'account_financial_cnab'

# Informações adicionais

Dados da tarefa: [T6541](https://multi.multidados.tech/web?#id=6950&action=328&model=project.task&view_type=form&menu_id=223)

PR(s) relacionado(s) (se houver): [442](https://github.com/multidadosti-erp/multidadosti-financial-addons/pull/442)
